### PR TITLE
refactor(main): return Result from main and simplify error handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,17 +3,8 @@ mod error;
 mod qck;
 
 use error::Result;
-use std::process;
 
-fn main() {
-    // Run the application and handle any errors
-    if let Err(err) = run() {
-        eprintln!("Error: {}", err);
-        process::exit(1);
-    }
-}
-
-fn run() -> Result<()> {
+fn main() -> Result<()> {
     // Parse command line arguments
     let args = cli::fetch_cli_args();
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refactor `main()` in `src/main.rs` to return `Result<()>`, simplifying error handling by removing the `run()` function.
> 
>   - **Refactor**:
>     - `main()` in `src/main.rs` now returns `Result<()>`, removing the need for a separate `run()` function.
>     - Simplifies error handling by leveraging Rust's `Result` type instead of manual error handling with `process::exit`.
>   - **Misc**:
>     - Removed `run()` function from `src/main.rs` as it is no longer needed.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=zapp88%2Fqckprism&utm_source=github&utm_medium=referral)<sup> for 87236a8b88019d02c7f5dcf7b985322787ac1f10. You can [customize](https://app.ellipsis.dev/zapp88/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->